### PR TITLE
エラーに対するfactorybotの記載の修正ついて

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
             bundle exec rails db:create db:migrate
             TEST_FILES="$(circleci tests glob \"spec/**/*_spec.rb\" | circleci tests split --split-by=timings)"
             bundle exec rspec --require rails_helper \
+                              --format RspecJunitFormatter \
                               --color \
                               --format progress \
                               --out ~/rspec/rspec.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
             bundle exec rails db:create db:migrate
             TEST_FILES="$(circleci tests glob \"spec/**/*_spec.rb\" | circleci tests split --split-by=timings)"
             bundle exec rspec --require rails_helper \
-                              --format RspecJunitFormatter \
                               --color \
                               --format progress \
                               --out ~/rspec/rspec.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
             bundle exec rspec --require rails_helper \
                               --color \
                               --format progress \
+                              --format RspecJunitFormatter \
                               --out ~/rspec/rspec.xml
       - store_test_results:
           path: ~/rspec

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem "pry-doc"
   gem "pry-rails"
   gem "rspec-rails"
+  gem "rspec_junit_formatter"
   gem "rubocop-performance"
   gem "rubocop-rails", require: false
   gem "rubocop-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -299,6 +301,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-erd
   rspec-rails
+  rspec_junit_formatter
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   # nameは入力必須にする
   validates :name, presence: true
   # accountは入力必須、重複禁止
-  validates :account, presence: true, uniqueness: true
+  validates :account, presence: true
 
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/db/migrate/20200504050859_add_account_to_users.rb
+++ b/db/migrate/20200504050859_add_account_to_users.rb
@@ -1,0 +1,5 @@
+class AddAccountToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :account, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_01_221505) do
+ActiveRecord::Schema.define(version: 2020_05_04_050859) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_221505) do
     t.text "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "account"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :article_like do
-    user { nil }
-    article { nil }
+    user
+    article
   end
 end

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :article_like do
+    user { "" }
+    article { nil }
   end
 end

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :article_like do
-    user { "" }
+    user { nil }
     article { nil }
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :article do
-    title { Faker::Lorem.characters(number: Random.new.rand(1..100)) }
+    title { Faker::Lorem.characters(number: Random.new.rand(1..50)) }
     body { Faker::Lorem.paragraph }
     status { :draft }
     user

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,6 +1,12 @@
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "MyText" }
+    title { Faker::Lorem.characters(number: Random.new.rand(1..100)) }
+    body { Faker::Lorem.paragraph }
+    status { :draft }
+    user
+
+    trait :published_status do
+      status { :published }
+    end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     status { :draft }
     user
 
-    trait :published_status do
+    trait :published do
       status { :published }
     end
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :comment do
-    body { "MyText" }
+    # 文字列、行、文章
+    body { Faker::Lorem.sentence }
+    user
+    article
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    # sequenceを使って重複しないようにする
+    sequence(:account) {|n| "#{n}_#{Faker::Internet.username}" }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 12, mix_case: true) }
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -9,20 +9,13 @@ RSpec.describe Article, type: :model do
       end
     end
 
-    context "下書きとして投稿する場合" do
+    context "下書きと公開記事として投稿する場合" do
       let(:article) { build(:article, status: "draft") }
-      it "下書き記事が投稿される" do
-        expect(article).to be_valid
-
-        expect(article.status).to eq "draft"
-      end
-    end
-
-    context "公開記事として投稿する場合" do
-      let(:article) { build(:article, status: "published") }
-      it "公開記事が投稿される" do
-        expect(article).to be_valid
-        expect(article.status).to eq "published"
+      it "下書きと公開記事として投稿される" do
+        aggregate_failures "testing items" do
+          expect(article).to be_valid
+          expect(article.status).to eq "draft"
+        end
       end
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  describe "正常テスト" do
+  describe "正常系テスト" do
     context "タイトル、本文が入力されているとき" do
       let(:article) { build(:article) }
       it "記事が投稿される" do
@@ -20,7 +20,7 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  describe "異常テスト" do
+  describe "異常系テスト" do
     context "タイトルが入力されていないとき" do
       let(:article) { build(:article, title: nil) }
       it "エラーする" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,5 +1,30 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常テスト" do
+    context "タイトル、本文が入力されているとき" do
+      let(:article) { build(:article) }
+      it "記事が投稿される" do
+        expect(article).to be_valid
+      end
+    end
+  end
+
+  describe "異常テスト" do
+    context "タイトルが入力されていないとき" do
+      let(:article) { build(:article, titile: nil) }
+      it "エラーする" do
+        article.valid?
+        expect(article.errors.messages[:titile]).to include "can't be blank"
+      end
+    end
+
+    context "本文が入力されていないとき" do
+      let(:article) { build(:article, body: nil) }
+      it "エラーする" do
+        article.valid?
+        expect(article.errors.messages[:body]).to include "can't be blank"
+      end
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,14 +8,31 @@ RSpec.describe Article, type: :model do
         expect(article).to be_valid
       end
     end
+
+    context "下書きとして投稿する場合" do
+      let(:article) { build(:article, status: "draft") }
+      it "下書き記事が投稿される" do
+        expect(article).to be_valid
+
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "公開記事として投稿する場合" do
+      let(:article) { build(:article, status: "published") }
+      it "公開記事が投稿される" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
+    end
   end
 
   describe "異常テスト" do
     context "タイトルが入力されていないとき" do
-      let(:article) { build(:article, titile: nil) }
+      let(:article) { build(:article, title: nil) }
       it "エラーする" do
         article.valid?
-        expect(article.errors.messages[:titile]).to include "can't be blank"
+        expect(article.errors.messages[:title]).to include "can't be blank"
       end
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,19 +1,19 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  describe "正常テスト" do
+  describe "正常系テスト" do
     context "コメントが入力されているとき" do
       let(:comment) { build(:comment) }
-      it "投稿できます" do
+      it "投稿できる" do
         expect(comment).to be_valid
       end
     end
   end
 
-  describe "異常テスト" do
+  describe "異常系テスト" do
     context "コメントが入力されていないとき" do
       let(:comment) { build(:comment, body: nil) }
-      it "投稿できません" do
+      it "投稿できない" do
         comment.valid?
         expect(comment.errors.messages[:body]).to include "can't be blank"
       end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,5 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常テスト" do
+    context "コメントが入力されているとき" do
+      let(:comment) { build(:comment) }
+      it "投稿できます" do
+        expect(comment).to be_valid
+      end
+    end
+  end
+
+  describe "異常テスト" do
+    context "コメントが入力されていないとき" do
+      let(:comment) { build(:comment, body: nil) }
+      it "投稿できません" do
+        comment.valid?
+        expect(comment.errors.messages[:body]).to include "can't be blank"
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
+require "pry"
 
 RSpec.describe User, type: :model do
-  describe "正常テスト" do
+  describe "正常系テスト" do
     context "名前,アカウント,email,パスワードが入力されているとき" do
       let(:user) { build(:user) } # let（共通処理の変数化）let(:定義名) {定義の内容、つまりRspecで行う処理} build/FactoryBotのインスタンスを作るメソッド
       it "ユーザが作成できる" do
@@ -10,12 +11,13 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "異常テスト" do
+  describe "異常系テスト" do
+    subject { user.valid? }
+
     describe "名前について" do
       context "名前が入力されていないとき" do
         let(:user) { build(:user, name: nil) }
-        it "エラーです" do
-          user.valid?
+        it "エラーする" do
           expect(user.errors.messages[:name]).to include "can't be blank"
         end
       end
@@ -24,8 +26,7 @@ RSpec.describe User, type: :model do
     describe "アカウントについて" do
       context "アカウントが入力されていないとき" do
         let(:user) { build(:user, account: nil) }
-        it "エラーです" do
-          user.valid?
+        it "エラーする" do
           expect(user.errors.messages[:account]).to include "can't be blank"
         end
       end
@@ -34,20 +35,20 @@ RSpec.describe User, type: :model do
     describe "emailについて" do
       context "emailが入力されていないとき" do
         let(:user) { build(:user, email: nil) }
-        it "エラーです" do
-          user.valid?
+        it "エラーする" do
           expect(user.errors.messages[:email]).to include "can't be blank"
         end
       end
 
       context "同一のemailが存在する" do
+        let(email) { fushifushi@example.com }
         before do
-          create(:user, email: "fushifushi@example.com")
+          create(:user, email: email)
         end
 
-        let(:user) { build(:user, email: "fushifushi@example.com") }
-        it "エラーです" do
-          user.valid?
+        it "エラーする" do
+          let(:user) { build(:user, email: email) }
+          binding.pry
           expect(user.errors.messages[:email]).to include "has already been taken"
         end
       end
@@ -55,7 +56,6 @@ RSpec.describe User, type: :model do
       context "emailに@が含まれない時" do
         let(:user) { build(:user, email: "fushifushiexample.com") }
         it "エラーする" do
-          user.valid?
           expect(user.errors.messages[:email]).to include "is not an email"
         end
       end
@@ -65,7 +65,6 @@ RSpec.describe User, type: :model do
       context "パスワードが入力されていない時" do
         let(:user) { build(:user, password: nil) }
         it "エラーする" do
-          user.valid?
           expect(user.errors.messages[:password]).to include "can't be blank"
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,71 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常テスト" do
+    context "名前,アカウント,email,パスワードが入力されているとき" do
+      let(:user) { build(:user) } # let（共通処理の変数化）let(:定義名) {定義の内容、つまりRspecで行う処理} build/FactoryBotのインスタンスを作るメソッド
+      it "ユーザが作成できる" do
+        expect(user).to be_valid # matcher(be_***)
+      end
+    end
+  end
+
+  describe "異常テスト" do
+    describe "名前について" do
+      context "名前が入力されていないとき" do
+        it "エラーです" do
+          user = build(:user, name: nil)
+          user.valid?
+          expect(user.errors.messages[:name]).to include "can't be blank"
+        end
+      end
+    end
+
+    describe "アカウントについて" do
+      context "アカウントが入力されていないとき" do
+        it "エラーです" do
+          user = build(:user, account: nil)
+          user.valid?
+          expect(user.errors.messages[:account]).to include "can't be blank"
+        end
+      end
+    end
+
+    describe "emailについて" do
+      context "emailが入力されていないとき" do
+        it "エラーです" do
+          user = build(:user, email: nil)
+          user.valid?
+          expect(user.errors.messages[:email]).to include "can't be blank"
+        end
+      end
+
+      context "同一のemailが存在する" do
+        it "エラーです" do
+          create(:user, email: "fushifushi@example.com")
+          user = build(:user, email: "fushifushi@example.com")
+          user.valid?
+          expect(user.errors.messages[:email]).to include "Already used"
+        end
+      end
+
+      context "emailに@が含まれない時" do
+        it "エラーする" do
+          user = build(:user, email: "tsuruokaexample.com")
+          user.valid?
+          expect(user.errors.messages[:email]).to include "is not an email"
+        end
+      end
+    end
+
+    describe "パスワードについて" do
+      context "パスワードが入力されていない時" do
+        it "エラーする" do
+          user = build(:user, password: nil)
+          user.valid?
+          expect(user.errors.messages[:password]).to include "can't be blank"
+        end
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe User, type: :model do
   describe "異常テスト" do
     describe "名前について" do
       context "名前が入力されていないとき" do
+        let(:user) { build(:user, name: nil) }
         it "エラーです" do
-          user = build(:user, name: nil)
           user.valid?
           expect(user.errors.messages[:name]).to include "can't be blank"
         end
@@ -23,8 +23,8 @@ RSpec.describe User, type: :model do
 
     describe "アカウントについて" do
       context "アカウントが入力されていないとき" do
+        let(:user) { build(:user, account: nil) }
         it "エラーです" do
-          user = build(:user, account: nil)
           user.valid?
           expect(user.errors.messages[:account]).to include "can't be blank"
         end
@@ -33,25 +33,26 @@ RSpec.describe User, type: :model do
 
     describe "emailについて" do
       context "emailが入力されていないとき" do
+        let(:user) { build(:user, email: nil) }
         it "エラーです" do
-          user = build(:user, email: nil)
           user.valid?
           expect(user.errors.messages[:email]).to include "can't be blank"
         end
       end
 
       context "同一のemailが存在する" do
+        before { create(:user, email: "fushifushi@example.com") }
+
+        let(:user) { build(:user, email: "fushifushi@example.com") }
         it "エラーです" do
-          create(:user, email: "fushifushi@example.com")
-          user = build(:user, email: "fushifushi@example.com")
           user.valid?
           expect(user.errors.messages[:email]).to include "Already used"
         end
       end
 
       context "emailに@が含まれない時" do
+        let(:user) { build(:user, email: "fushifushiexample.com") }
         it "エラーする" do
-          user = build(:user, email: "tsuruokaexample.com")
           user.valid?
           expect(user.errors.messages[:email]).to include "is not an email"
         end
@@ -60,8 +61,8 @@ RSpec.describe User, type: :model do
 
     describe "パスワードについて" do
       context "パスワードが入力されていない時" do
+        let(:user) { build(:user, password: nil) }
         it "エラーする" do
-          user = build(:user, password: nil)
           user.valid?
           expect(user.errors.messages[:password]).to include "can't be blank"
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,12 +41,14 @@ RSpec.describe User, type: :model do
       end
 
       context "同一のemailが存在する" do
-        before { create(:user, email: "fushifushi@example.com") }
+        before do
+          create(:user, email: "fushifushi@example.com")
+        end
 
         let(:user) { build(:user, email: "fushifushi@example.com") }
         it "エラーです" do
           user.valid?
-          expect(user.errors.messages[:email]).to include "Already used"
+          expect(user.errors.messages[:email]).to include "has already been taken"
         end
       end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 Faker::Config.locale = :ja
+require "support/factory_bot"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 Faker::Config.locale = :ja
-require "support/factory_bot"
+# require "support/factory_bot"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,6 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
-
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   #   # This allows you to limit a spec run to individual examples or groups

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
Task.6-3 model の validation テストの実装】の「3. 各model に追加した validation のテストを実装する」部分の質問です。
現在、テスト実装が終了し、 bundle exec rspec でテストを走らせ、下記のエラーが出ています。
お時間がある時にアドバイス頂けますと幸いです。宜しくお願い申し上げます。

> Failures:
>   1) Article 正常テスト タイトル、本文が入力されているとき 記事が投稿される
>      Failure/Error: let(:article) { build(:article) }
>      NoMethodError:
>        undefined method `account=' for #<User:0x00007f800f36ebb0>
>      # ./spec/models/article_spec.rb:6:in `block (4 levels) in <main>'
>      # ./spec/models/article_spec.rb:8:in `block (4 levels) in <main>'

### 「解決したい事」
上記のエラーの解決し、テストを成功させる

### 「エラーについて考えている事」
以前、ウェブ系ウシジマくん さんに指摘頂いた通り、

①`undefined method account` とあり、accountメソッドが見つからない。
②`Failure/Error: let(:
./spec/models/article_spec.rb `内に account の記載はないですが、どこから参照されて値が使われているので、このエラーが出ている。

`Failure/Error: let(:article) { build(:article) }`  で定義しているlet(:article) のarticleのfactoryの記載に問題があるのではないか？と考えていますが、accountにつながる記載方法が分かりません。そもそも、accountの記載のあるuserのfactorybotの記載も問題であるのでしょうか？

### 「レビューして頂きたい事」
・今回のエラーについての考え方
・factorybotの記載のチェック